### PR TITLE
Connection from haskell

### DIFF
--- a/connection.hs
+++ b/connection.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import Database.MySQL.Base
+import qualified System.IO.Streams as Streams
+
+main :: IO () 
+main = do
+    conn <- connect
+        ConnectInfo {ciHost = "jfaldanam.ddns.net", ciPort = 3306, ciDatabase = "GIHaskell",
+                     ciUser = "martin", ciPassword = "password_martin", ciCharset = 33}
+    (defs, is) <- query_ conn "SELECT * FROM tUsuario"
+    print =<< Streams.toList is


### PR DESCRIPTION
Para tener las librerias de hdbc usad este comando en el CMD de windows:
cabal install myqsl-haskell

Con esto ya puedes usar los modulos de hdbc.
El archivo connection es un test para ver si se conecta bien al servidor y recoge la información de usuarios de la base de datos en una lista.